### PR TITLE
Feat: Add the get early attendees feature for admins

### DIFF
--- a/src/main/java/com/example/attendance_system/controller/AdminController.java
+++ b/src/main/java/com/example/attendance_system/controller/AdminController.java
@@ -1,35 +1,46 @@
 package com.example.attendance_system.controller;
 
 import com.example.attendance_system.dto.UserDTO;
+import com.example.attendance_system.exceptions.AttendanceServiceException;
 import com.example.attendance_system.exceptions.UnauthorizedUserException;
 import com.example.attendance_system.exceptions.UserNotFoundException;
+import com.example.attendance_system.model.Attendance;
 import com.example.attendance_system.role.FacilitatorRole;
 import com.example.attendance_system.role.NSPRole;
 import com.example.attendance_system.request.RegisterRequest;
 import com.example.attendance_system.request.UpdateUserRequest;
 import com.example.attendance_system.model.User;
+import com.example.attendance_system.service.AttendanceService;
 import com.example.attendance_system.service.UserService;
 import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/admin")
 @PreAuthorize("hasRole('ADMIN')")
 @RequiredArgsConstructor
+@Slf4j
 public class AdminController {
     private final UserService userService;
+    private final AttendanceService attendanceService;
 
     @PostMapping("/create-nsp")
     public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) throws MessagingException {
@@ -112,6 +123,35 @@ public class AdminController {
                 return buildErrorResponse("You are not authorized to perform this action", HttpStatus.FORBIDDEN);
             }
         }
+
+        //get early attendee
+
+    @GetMapping("/early-attendees")
+    public ResponseEntity<?> getEarlyAttendees(
+            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "100") int size) {
+
+        try {
+            Page<Attendance> earlyAttendees = attendanceService.getEarlyAttendees(startDate, endDate, page, size);
+            return ResponseEntity.ok(earlyAttendees);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid request parameters: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+        } catch (AttendanceServiceException e) {
+            log.error("Service error while getting early attendees", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("Failed to retrieve early attendees"));
+        }
+    }
+
+    // Simple error response class
+    @Data
+    private static class ErrorResponse {
+        private final String message;
+        private final LocalDateTime timestamp = LocalDateTime.now();
+    }
 
 
         //Helper method to handle error messages

--- a/src/main/java/com/example/attendance_system/exceptions/AttendanceServiceException.java
+++ b/src/main/java/com/example/attendance_system/exceptions/AttendanceServiceException.java
@@ -1,0 +1,8 @@
+package com.example.attendance_system.exceptions;
+
+public class AttendanceServiceException extends RuntimeException {
+    public AttendanceServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/example/attendance_system/repository/AttendanceRepository.java
+++ b/src/main/java/com/example/attendance_system/repository/AttendanceRepository.java
@@ -1,7 +1,20 @@
 package com.example.attendance_system.repository;
 
 import com.example.attendance_system.model.Attendance;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+    @Query("SELECT a FROM Attendance a WHERE a.checkInTime >= :startDateTime AND a.checkInTime <= :endDateTime")
+    Page<Attendance> findAttendeesBetweenDates(
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime,
+            Pageable pageable);
 }

--- a/src/main/java/com/example/attendance_system/service/AttendanceService.java
+++ b/src/main/java/com/example/attendance_system/service/AttendanceService.java
@@ -1,5 +1,6 @@
 package com.example.attendance_system.service;
 
+import com.example.attendance_system.exceptions.AttendanceServiceException;
 import com.example.attendance_system.exceptions.InvalidSessionException;
 import com.example.attendance_system.exceptions.ResourceNotFoundException;
 import com.example.attendance_system.exceptions.UserNotFoundException;
@@ -9,10 +10,18 @@ import com.example.attendance_system.repository.SessionRepository;
 import com.example.attendance_system.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +30,8 @@ public class AttendanceService {
     private final AttendanceRepository attendanceRepository;
     private final SessionRepository sessionRepository;
     private final UserRepository  userRepository;
+    private static final LocalTime DEFAULT_EARLY_TIME = LocalTime.of(7, 30);
+    private static final int DEFAULT_PAGE_SIZE = 100;
 
     public String createAttendance(String sessionCode) {
         var session = sessionRepository.findBySessionCode(sessionCode)
@@ -40,5 +51,65 @@ public class AttendanceService {
         log.info("Attendance logged for user with mail: {}", user.getEmail());
 
         return "Attendance recorded successfully";
+    }
+
+
+    /**
+     * Retrieves attendees who checked in early within the specified date range.
+     *
+     * @param startDate The start date (inclusive) for the search range
+     * @param endDate The end date (inclusive) for the search range
+     * @param page The page number (zero-based)
+     * @param size The page size
+     * @return A page of early attendees
+     * @throws IllegalArgumentException if date parameters are invalid
+     */
+    public Page<Attendance> getEarlyAttendees(LocalDate startDate, LocalDate endDate, int page, int size) {
+        // Validate inputs
+        validateDateRange(startDate, endDate);
+
+        // Set up pagination - use default values if invalid parameters are provided
+        page = Math.max(0, page);
+        size = (size <= 0) ? DEFAULT_PAGE_SIZE : size;
+        Pageable pageable = PageRequest.of(page, size);
+
+        try {
+            LocalDateTime startDateTime = startDate.atStartOfDay();
+            LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay().minusNanos(1);
+
+            Page<Attendance> allAttendees = attendanceRepository.findAttendeesBetweenDates(
+                    startDateTime, endDateTime, pageable);
+
+            // Filter in Java instead of in the database
+            List<Attendance> earlyAttendees = allAttendees.getContent().stream()
+                    .filter(a -> a.getCheckInTime().toLocalTime().isBefore(DEFAULT_EARLY_TIME))
+                    .collect(Collectors.toList());
+
+            return new PageImpl<>(earlyAttendees, pageable, earlyAttendees.size());
+        } catch (Exception e) {
+            log.error("Error retrieving early attendees", e);
+            throw new AttendanceServiceException("Failed to retrieve early attendees", e);
+        }
+    }
+
+    /**
+     * Validates that the provided date range is valid.
+     *
+     * @param startDate The start date
+     * @param endDate The end date
+     * @throws IllegalArgumentException if dates are null or startDate is after endDate
+     */
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null) {
+            throw new IllegalArgumentException("Start date cannot be null");
+        }
+
+        if (endDate == null) {
+            throw new IllegalArgumentException("End date cannot be null");
+        }
+
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("Start date cannot be after end date");
+        }
     }
 }

--- a/src/test/java/com/example/attendance_system/service/AttendanceServiceTest.java
+++ b/src/test/java/com/example/attendance_system/service/AttendanceServiceTest.java
@@ -1,0 +1,183 @@
+package com.example.attendance_system.service;
+import com.example.attendance_system.exceptions.AttendanceServiceException;
+import com.example.attendance_system.model.Attendance;
+import com.example.attendance_system.repository.AttendanceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AttendanceServiceTest {
+
+    @Mock
+    private AttendanceRepository attendanceRepository;
+
+    @InjectMocks
+    private AttendanceService attendanceService;
+
+    @Captor
+    private ArgumentCaptor<LocalDateTime> startDateTimeCaptor;
+
+    @Captor
+    private ArgumentCaptor<LocalDateTime> endDateTimeCaptor;
+
+    @Captor
+    private ArgumentCaptor<Pageable> pageableCaptor;
+
+    private static final LocalTime EARLY_TIME = LocalTime.of(7, 30);
+    private static final LocalDate START_DATE = LocalDate.of(2023, 5, 1);
+    private static final LocalDate END_DATE = LocalDate.of(2023, 5, 7);
+
+    @Test
+    void getEarlyAttendees_ValidDates_ReturnsEarlyAttendees() {
+        // Arrange
+        Attendance earlyAttendee = createAttendance(1L, LocalDateTime.of(START_DATE, LocalTime.of(7, 0)));
+        Attendance regularAttendee = createAttendance(2L, LocalDateTime.of(START_DATE, LocalTime.of(8, 0)));
+
+        List<Attendance> allAttendees = Arrays.asList(earlyAttendee, regularAttendee);
+        Page<Attendance> attendeesPage = new PageImpl<>(allAttendees, PageRequest.of(0, 10), allAttendees.size());
+
+        when(attendanceRepository.findAttendeesBetweenDates(
+                any(LocalDateTime.class), any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(attendeesPage);
+
+        // Act
+        Page<Attendance> result = attendanceService.getEarlyAttendees(START_DATE, END_DATE, 0, 10);
+
+        // Assert
+        assertEquals(1, result.getContent().size());
+        assertEquals(earlyAttendee.getId(), result.getContent().get(0).getId());
+
+        verify(attendanceRepository).findAttendeesBetweenDates(
+                startDateTimeCaptor.capture(), endDateTimeCaptor.capture(), pageableCaptor.capture());
+
+        assertEquals(START_DATE.atStartOfDay(), startDateTimeCaptor.getValue());
+        assertEquals(END_DATE.plusDays(1).atStartOfDay().minusNanos(1), endDateTimeCaptor.getValue());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(10, pageableCaptor.getValue().getPageSize());
+    }
+
+    @Test
+    void getEarlyAttendees_NoEarlyAttendees_ReturnsEmptyPage() {
+        // Arrange
+        Attendance regularAttendee = createAttendance(1L, LocalDateTime.of(START_DATE, LocalTime.of(8, 0)));
+        List<Attendance> allAttendees = Collections.singletonList(regularAttendee);
+        Page<Attendance> attendeesPage = new PageImpl<>(allAttendees, PageRequest.of(0, 10), allAttendees.size());
+
+        when(attendanceRepository.findAttendeesBetweenDates(
+                any(LocalDateTime.class), any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(attendeesPage);
+
+        // Act
+        Page<Attendance> result = attendanceService.getEarlyAttendees(START_DATE, END_DATE, 0, 10);
+
+        // Assert
+        assertTrue(result.getContent().isEmpty());
+    }
+
+    @Test
+    void getEarlyAttendees_NegativePage_UsesPageZero() {
+        // Arrange
+        when(attendanceRepository.findAttendeesBetweenDates(
+                any(LocalDateTime.class), any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        // Act
+        attendanceService.getEarlyAttendees(START_DATE, END_DATE, -1, 10);
+
+        // Assert
+        verify(attendanceRepository).findAttendeesBetweenDates(
+                any(LocalDateTime.class), any(LocalDateTime.class), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+    }
+
+    @Test
+    void getEarlyAttendees_ZeroSize_UsesDefaultSize() {
+        // Arrange
+        when(attendanceRepository.findAttendeesBetweenDates(
+                any(LocalDateTime.class), any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        // Act
+        attendanceService.getEarlyAttendees(START_DATE, END_DATE, 0, 0);
+
+        // Assert
+        verify(attendanceRepository).findAttendeesBetweenDates(
+                any(LocalDateTime.class), any(LocalDateTime.class), pageableCaptor.capture());
+        assertEquals(100, pageableCaptor.getValue().getPageSize());
+    }
+
+    @Test
+    void getEarlyAttendees_NullStartDate_ThrowsIllegalArgumentException() {
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                attendanceService.getEarlyAttendees(null, END_DATE, 0, 10));
+        assertEquals("Start date cannot be null", exception.getMessage());
+
+        verify(attendanceRepository, never()).findAttendeesBetweenDates(any(), any(), any());
+    }
+
+    @Test
+    void getEarlyAttendees_NullEndDate_ThrowsIllegalArgumentException() {
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                attendanceService.getEarlyAttendees(START_DATE, null, 0, 10));
+        assertEquals("End date cannot be null", exception.getMessage());
+
+        verify(attendanceRepository, never()).findAttendeesBetweenDates(any(), any(), any());
+    }
+
+    @Test
+    void getEarlyAttendees_StartDateAfterEndDate_ThrowsIllegalArgumentException() {
+        // Arrange
+        LocalDate laterDate = LocalDate.of(2023, 5, 10);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                attendanceService.getEarlyAttendees(laterDate, START_DATE, 0, 10));
+        assertEquals("Start date cannot be after end date", exception.getMessage());
+
+        verify(attendanceRepository, never()).findAttendeesBetweenDates(any(), any(), any());
+    }
+
+    @Test
+    void getEarlyAttendees_RepositoryThrowsException_ThrowsAttendanceServiceException() {
+        // Arrange
+        when(attendanceRepository.findAttendeesBetweenDates(
+                any(LocalDateTime.class), any(LocalDateTime.class), any(Pageable.class)))
+                .thenThrow(new RuntimeException("Database error"));
+
+        // Act & Assert
+        AttendanceServiceException exception = assertThrows(AttendanceServiceException.class, () ->
+                attendanceService.getEarlyAttendees(START_DATE, END_DATE, 0, 10));
+        assertEquals("Failed to retrieve early attendees", exception.getMessage());
+    }
+
+    private Attendance createAttendance(Long id, LocalDateTime checkInTime) {
+        Attendance attendance = new Attendance();
+        attendance.setId(id);
+        attendance.setCheckInTime(checkInTime);
+        return attendance;
+    }
+}


### PR DESCRIPTION
The Early Attendees feature provides functionality to retrieve attendance records for individuals who arrived early (before 7:30 AM) within a specified date range. The implementation includes a service method to fetch and filter the data, and a REST endpoint to expose this functionality via a web API